### PR TITLE
sama5d2_xplained: ensure proper bootargs are defined

### DIFF
--- a/include/configs/sama5d2_xplained.h
+++ b/include/configs/sama5d2_xplained.h
@@ -123,7 +123,10 @@
 #undef CONFIG_BOOTARGS
 #define CONFIG_BOOTARGS \
 	"console=ttyS0,115200 earlyprintk root=/dev/mmcblk1p2 rw rootwait"
-
+#else
+#undef CONFIG_BOOTARGS
+#define CONFIG_BOOTARGS \
+	"console=ttyS0,115200 earlyprintk root=/dev/mmcblk1p1 rw rootwait"
 #endif
 
 /* SPL */


### PR DESCRIPTION
The sama5d2_xplained doesn't have a NAND flash and the rootfs always end up
on the MMC. Ensure we always try to boot from there.

Signed-off-by: Alexandre Belloni <alexandre.belloni@free-electrons.com>