### PR TITLE
Bugfix/u boot env offset

### DIFF
--- a/include/configs/at91sam9260ek.h
+++ b/include/configs/at91sam9260ek.h
@@ -185,7 +185,7 @@
 #define CONFIG_BOOTARGS							\
 	"console=ttyS0,115200 earlyprintk "				\
 	"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-	"256k(env),256k(env_redundant),256k(spare),"			\
+	"256k(spare),256k(env_redundant),256k(env),"			\
 	"512k(dtb),6M(kernel)ro,-(rootfs) "				\
 	"root=/dev/mtdblock7 rw rootfstype=jffs2"
 

--- a/include/configs/at91sam9261ek.h
+++ b/include/configs/at91sam9261ek.h
@@ -170,14 +170,14 @@
 
 /* bootstrap + u-boot + env + linux in nandflash */
 #define CONFIG_ENV_IS_IN_NAND
-#define CONFIG_ENV_OFFSET		0xc0000
+#define CONFIG_ENV_OFFSET		0x140000
 #define CONFIG_ENV_OFFSET_REDUND	0x100000
 #define CONFIG_ENV_SIZE		0x20000		/* 1 sector = 128 kB */
 #define CONFIG_BOOTCOMMAND	"nand read 0x22000000 0x200000 0x300000; bootm"
 #define CONFIG_BOOTARGS							\
 	"console=ttyS0,115200 earlyprintk "				\
 	"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-	"256k(env),256k(env_redundant),256k(spare),"			\
+	"256k(spare),256k(env_redundant),256k(env),"			\
 	"512k(dtb),6M(kernel)ro,-(rootfs) "				\
 	"root=/dev/mtdblock7 rw rootfstype=jffs2"
 #endif

--- a/include/configs/at91sam9263ek.h
+++ b/include/configs/at91sam9263ek.h
@@ -276,7 +276,7 @@
 #define CONFIG_BOOTARGS							\
 	"console=ttyS0,115200 earlyprintk "				\
 	"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-	"256k(env),256k(env_redundant),256k(spare),"			\
+	"256k(spare),256k(env_redundant),256k(env),"			\
 	"512k(dtb),6M(kernel)ro,-(rootfs) "				\
 	"root=/dev/mtdblock7 rw rootfstype=jffs2"
 #endif

--- a/include/configs/at91sam9m10g45ek.h
+++ b/include/configs/at91sam9m10g45ek.h
@@ -102,7 +102,7 @@
 #define CONFIG_BOOTARGS							\
 	"console=ttyS0,115200 earlyprintk "				\
 	"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-	"256k(env),256k(env_redundant),256k(spare),"			\
+	"256k(spare),256k(env_redundant),256k(env),"			\
 	"512k(dtb),6M(kernel)ro,-(rootfs) "				\
 	"root=/dev/mtdblock7 rw rootfstype=jffs2"
 #elif CONFIG_SYS_USE_MMC

--- a/include/configs/at91sam9n12ek.h
+++ b/include/configs/at91sam9n12ek.h
@@ -98,7 +98,7 @@
 #define MTDIDS_DEFAULT			"nand0=atmel_nand"
 #define MTDPARTS_DEFAULT						\
 	"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-	"256k(env),256k(env_redundant),256k(spare),"			\
+	"256k(spare),256k(env_redundant),256k(env),"			\
 	"512k(dtb),6M(kernel)ro,-(rootfs)"
 
 #define CONFIG_EXTRA_ENV_SETTINGS                                       \

--- a/include/configs/at91sam9rlek.h
+++ b/include/configs/at91sam9rlek.h
@@ -123,7 +123,7 @@
 #define CONFIG_BOOTARGS		\
 				"console=ttyS0,115200 earlyprintk "				\
 				"mtdparts=atmel_nand:256k(bootstrap)ro,512k(uboot)ro,"		\
-				"256K(env),256k(env_redundant),256k(spare),"			\
+				"256K(spare),256k(env_redundant),256k(env),"			\
 				"512k(dtb),6M(kernel)ro,-(rootfs) "				\
 				"rootfstype=ubifs ubi.mtd=7 root=ubi0:rootfs"
 


### PR DESCRIPTION
Hi,

This is a small fix of mtdparts u-boot parameters that don't match CONFIG_ENV_OFFSET value since the define has been updated in commit 4744f870b23d7f84d13aa767835b3a457e34e181.

I have seen the issue when I have updated a at91sam9g45-ekes board. sam-ba script still point on old address for u-boot-env. A sam-ba script fix is also submitted on [meta-atmel](https://github.com/linux4sam/meta-atmel/pull/106).

I was only able to test it on at91sam9g45ekes board.

Regards