### PR TITLE
ARM: dts: sama7d65.dtsi: Fix SDMMC0 clock parents assigned

### DIFF
--- a/arch/arm/dts/sama7d65.dtsi
+++ b/arch/arm/dts/sama7d65.dtsi
@@ -360,9 +360,9 @@
 			interrupts = <GIC_SPI 75 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 75>, <&pmc PMC_TYPE_GCK 75>;
 			clock-names = "hclock", "multclk";
-			assigned-clock-parents = <&pmc PMC_TYPE_CORE 10>; /* sys pll div. */
 			assigned-clocks = <&pmc PMC_TYPE_GCK 75>;
 			assigned-clock-rates = <200000000>;
+			assigned-clock-parents = <&pmc PMC_TYPE_CORE 10>; /* MCK1 div */
 			microchip,sdcal-inverted;
 			status = "disabled";
 		};


### PR DESCRIPTION
In SPEC, Table 12.1. Peripheral Identifiers (page 51) states that the Clock Domain should be MCK1, but it is currently configured with an incorrect Clock Domain.

This will cause U-Boot to return the error:
mmc@e1204000 - probe failed: -22

and will prevent the SDMMC0 device from being used.


![image](https://github.com/user-attachments/assets/9952621c-3980-47ec-a39d-12b8dfb6011b)
